### PR TITLE
CI with ruby 2.0.0, 2.1, 2.2 and ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
+  - ruby-head
 script: bundle exec rake spec


### PR DESCRIPTION
CIでのRubyのバージョンが古かったので、tdiary-core と同じに揃えました。