### PR TITLE
pygments.rb から rouge に乗り換える

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; -*-
 
 require 'github/markdown'
-require 'pygments'
+require 'rouge'
 require 'twitter-text'
 
 module TDiary
@@ -65,7 +65,9 @@ module TDiary
 				# 2. Apply markdown conversion
 				r = GitHub::Markdown.to_html(r, :gfm) do |code, lang|
 					begin
-						Pygments.highlight(code, lexer: lang)
+						formatter = Rouge::Formatters::HTML.new(css_class: 'highlight')
+						lexer = Rouge::Lexers.const_get(lang.capitalize.to_sym).new
+						formatter.format(lexer.lex(code))
 					rescue Exception => ex
 						"<div class=\"highlight\"><pre>#{CGI.escapeHTML(code)}</pre></div>"
 					end

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -203,8 +203,9 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<div class="highlight"><pre><span class="vi">@foo</span>
-</pre></div>
+<pre class="highlight"><code><span class="vi">@foo</span>
+</code></pre>
+
 <p><a href="http://example.com">http://example.com</a> is example.com</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -324,10 +325,11 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<div class="highlight"><pre> <span class="k">def</span> <span class="nf">class</span>
-   <span class="vi">@foo</span> <span class="o">=</span> <span class="s1">&#39;bar&#39;</span>
+<pre class="highlight"><code> <span class="k">def</span> <span class="nf">class</span>
+   <span class="vi">@foo</span> <span class="o">=</span> <span class="s1">'bar'</span>
  <span class="k">end</span>
-</pre></div><%=section_leave_proc( Time.at( 1041346800 ) )%>
+</code></pre>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 			EOF
 		end

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'github-markdown'
-  spec.add_dependency 'pygments.rb'
+  spec.add_dependency 'rouge'
   spec.add_dependency 'twitter-text'
   spec.add_dependency 'emot'
 


### PR DESCRIPTION
python の pygments を spawn して highlight を実現する pygments.rb ではなく、 pure ruby で実現する rouge に乗り換えようと思います。syntax は div が pre, pre が code になりますが以下のプラグインを使って css を挿入している限りは

https://github.com/tdiary/tdiary-contrib/blob/master/plugin/pygments_css.rb

syntax 自体は崩れません。これでプロセスを生成するコストが抑えられると思います。