### PR TITLE
find specified language by Rouge::Lexer.find instead of const_get

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -65,7 +65,7 @@ module TDiary
 				# 2. Apply markdown conversion
 				r = GitHub::Markdown.to_html(r, :gfm) do |code, lang|
 					begin
-						formatter = Rouge::Formatters::HTML.new(css_class: 'highlight')
+						formatter = Rouge::Formatters::HTMLPygments.new(Rouge::Formatters::HTML.new, 'highlight')
 						lexer = Rouge::Lexer.find(lang)
 						formatter.format(lexer.lex(code))
 					rescue Exception => ex

--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -66,7 +66,7 @@ module TDiary
 				r = GitHub::Markdown.to_html(r, :gfm) do |code, lang|
 					begin
 						formatter = Rouge::Formatters::HTML.new(css_class: 'highlight')
-						lexer = Rouge::Lexers.const_get(lang.capitalize.to_sym).new
+						lexer = Rouge::Lexer.find(lang)
 						formatter.format(lexer.lex(code))
 					rescue Exception => ex
 						"<div class=\"highlight\"><pre>#{CGI.escapeHTML(code)}</pre></div>"

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -205,7 +205,6 @@ http://example.com is example.com
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <pre class="highlight"><code><span class="vi">@foo</span>
 </code></pre>
-
 <p><a href="http://example.com">http://example.com</a> is example.com</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -328,8 +327,7 @@ http://example.com is example.com
 <pre class="highlight"><code> <span class="k">def</span> <span class="nf">class</span>
    <span class="vi">@foo</span> <span class="o">=</span> <span class="s1">'bar'</span>
  <span class="k">end</span>
-</code></pre>
-<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</code></pre><%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 			EOF
 		end

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -449,7 +449,7 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<p><img src='http://www.emoji-cheat-sheet.com/graphics/emojis/sushi.png' width='20' height='20' title='sushi' alt='sushi' class='emoji' /> は美味しい</p>
+<p><img src='http://www.webpagefx.com/tools/emoji-cheat-sheet/graphics/emojis/sushi.png' width='20' height='20' title='sushi' alt='sushi' class='emoji' /> は美味しい</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 				EOF

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'github-markdown'
-  spec.add_dependency 'rouge'
+  spec.add_dependency 'rouge', '>= 2.0'
   spec.add_dependency 'twitter-text'
   spec.add_dependency 'emot'
 


### PR DESCRIPTION
[tDiaryユーザ掲示板にあった投稿](http://tdiary-users.osdn.jp/cgi-bin/wforum/wforum.cgi?no=6781&reno=no&oya=6781&mode=msgview&page=0)からおこしたPRです。未テスト(というか現状でテストが通ってないので、そこから直す必要がありそう):

```
ruby 2.3.1-p112
tdiary 5.0.1
tdiary-style-gfm 0.3.0
rouge 2.0.3
を使っています。

最近、「```ruby」のように言語を指定した場合に、
コード中の改行がなくなって全体が1行で表示され、また色も付いていない
ことに気付きました。

調べた結果、tdiary-style-gfm 0.3.0 が使用している rouge の仕様が
変わっていたためであることが判りました。

formatter = Rouge::Formatters::HTML.new(css_class: 'highlight')

の部分を

formatter = Rouge::Formatters::HTML.new
formatter = Rouge::Formatters::HTMLPygments.new(formatter, css_class='highlight')

と修正することで、手元では問題なく動作するようになりました。

また、rouge には言語名の alias 機能があり、"ruby" の代わりに "rb" とか、
"shell" の代わりに "sh" や "bash" とかが使えますが、tdiary-style-gfm 0.3.0 では
const_get を使って class 名を直接指定しているため使えません。

lexer = Rouge::Lexers.const_get(lang.capitalize.to_sym).new

の部分を

lexer = Rouge::Lexer.find(lang)

と修正することで alias 機能が効くようになりました。

以上 2点、ご検討いただければと思います。
よろしくお願いします。
```