### PR TITLE
Fix some expectations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.1
   - ruby-head
+matrix:
+  allowed_failures:
+    - rvm: ruby-head
+
 before_install: gem update bundler
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.1
+  - 2.3
+  - 2.4
   - ruby-head
 matrix:
   allowed_failures:

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -203,8 +203,8 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<pre class="highlight"><code><span class="vi">@foo</span>
-</code></pre>
+<div class="highlight"><pre class="highlight"><code><span class="vi">@foo</span>
+</code></pre></div>
 <p><a href="http://example.com">http://example.com</a> is example.com</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -324,10 +324,10 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<pre class="highlight"><code> <span class="k">def</span> <span class="nf">class</span>
+<div class="highlight"><pre class="highlight"><code> <span class="k">def</span> <span class="nf">class</span>
    <span class="vi">@foo</span> <span class="o">=</span> <span class="s1">'bar'</span>
  <span class="k">end</span>
-</code></pre><%=section_leave_proc( Time.at( 1041346800 ) )%>
+</code></pre></div><%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 			EOF
 		end
@@ -447,7 +447,7 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<p><img src='http://www.webpagefx.com/tools/emoji-cheat-sheet/graphics/emojis/sushi.png' width='20' height='20' title='sushi' alt='sushi' class='emoji' /> は美味しい</p>
+<p><img src='//www.webpagefx.com/tools/emoji-cheat-sheet/graphics/emojis/sushi.png' width='20' height='20' title='sushi' alt='sushi' class='emoji' /> は美味しい</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 				EOF

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{GFM Style for tDiary}
   spec.homepage      = "https://github.com/tdiary/tdiary-style-gfm"
   spec.license       = "GPL-3.0"
+  spec.required_ruby_version = [">= 2.2.0", "< 2.5.0"]
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{GFM Style for tDiary}
   spec.homepage      = "https://github.com/tdiary/tdiary-style-gfm"
   spec.license       = "GPL-3.0"
-  spec.required_ruby_version = [">= 2.2.0", "< 2.5.0"]
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
I found that some expectations got not suitable as tdiary-core has been updated. 
And as ruby 2.1.0 has been got rid of supports by tdiary-core so it should be also removed from supported ruby versions of this gem. 

This pull-request provides fixes so that all tests will pass and update on supported ruby versions. 
