### PR TITLE
rouge の lexer に option を渡せるようにした。

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -66,7 +66,7 @@ module TDiary
 				r = GitHub::Markdown.to_html(r, :gfm) do |code, lang|
 					begin
 						formatter = Rouge::Formatters::HTMLPygments.new(Rouge::Formatters::HTML.new, 'highlight')
-						lexer = Rouge::Lexer.find(lang)
+						lexer = Rouge::Lexer.find_fancy(lang)
 						formatter.format(lexer.lex(code))
 					rescue Exception => ex
 						"<div class=\"highlight\"><pre>#{CGI.escapeHTML(code)}</pre></div>"


### PR DESCRIPTION
`tdiary-style-gfm-0.4.1/lib/tdiary/style/gfm.rb` の syntax highlight 部分にに以下のコードがあります。

```rb
    lexer = Rouge::Lexer.find(lang)
```

言語名から Lexer を取得するコードですが、find では言語名しか渡すことができません。

以下のように find_fancy を使うと、

```rb
    lexer = Rouge::Lexer.find_fancy(lang)
```

この lang には、言語名だけでなく option も渡せるようになります。
具体的には `console?lang=csh&output=ruby&prompt=%` などと書けるように
なります。この例だと console が言語名で、それ以降は URL query の書き方で
option となります。

よろしくお願いします。
