### PR TITLE
avoid dependency of libidn

### DIFF
--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'github-markdown'
   spec.add_dependency 'rouge', '>= 2.2'
-  spec.add_dependency 'twitter-text'
+  spec.add_dependency 'twitter-text', '~> 1.0'
   spec.add_dependency 'emot'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
依存しているtwitter-text gemが、2.0からlibidnに依存するようになっており、これが入っていないプラットフォームが少なくないので当面は1.x固定にする。style-gfmはblogkitからも参照しているので、依存関係はシンプルにしておきたい。