### PR TITLE
Use commonmarker instead of github-markdown

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; -*-
 
 require 'commonmarker'
-require 'rouge'
 require 'twitter-text'
 
 module TDiary
@@ -64,7 +63,7 @@ module TDiary
 				r = replaced_r
 
 				# 2. Apply markdown conversion
-				r = CommonMarker.render_html(r, [:DEFAULT, :GITHUB_PRE_LANG], [:autolink])
+				r = CommonMarker.render_html(r, [:DEFAULT], [:autolink])
 
 				# 3. Stash <pre> and <code> tags
 				pre_tag_stashes = []

--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -64,7 +64,7 @@ module TDiary
 				r = replaced_r
 
 				# 2. Apply markdown conversion
-				r = CommonMarker.render_html(r, :DEFAULT) do |code, lang|
+				r = CommonMarker.render_html(r, :DEFAULT, [:autolink]) do |code, lang|
 					begin
 						formatter = Rouge::Formatters::HTMLPygments.new(Rouge::Formatters::HTML.new, 'highlight')
 						lexer = Rouge::Lexer.find_fancy(lang)

--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; -*-
 
-require 'github/markdown'
+require 'commonmarker'
 require 'rouge'
 require 'twitter-text'
 
@@ -64,7 +64,7 @@ module TDiary
 				r = replaced_r
 
 				# 2. Apply markdown conversion
-				r = GitHub::Markdown.to_html(r, :gfm) do |code, lang|
+				r = CommonMarker.render_html(r, :DEFAULT) do |code, lang|
 					begin
 						formatter = Rouge::Formatters::HTMLPygments.new(Rouge::Formatters::HTML.new, 'highlight')
 						lexer = Rouge::Lexer.find_fancy(lang)

--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -64,15 +64,7 @@ module TDiary
 				r = replaced_r
 
 				# 2. Apply markdown conversion
-				r = CommonMarker.render_html(r, :DEFAULT, [:autolink]) do |code, lang|
-					begin
-						formatter = Rouge::Formatters::HTMLPygments.new(Rouge::Formatters::HTML.new, 'highlight')
-						lexer = Rouge::Lexer.find_fancy(lang)
-						formatter.format(lexer.lex(code))
-					rescue Exception => ex
-						"<div class=\"highlight\"><pre>#{CGI.escapeHTML(code)}</pre></div>"
-					end
-				end
+				r = CommonMarker.render_html(r, [:DEFAULT, :GITHUB_PRE_LANG], [:autolink])
 
 				# 3. Stash <pre> and <code> tags
 				pre_tag_stashes = []

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -30,11 +30,8 @@ honbun
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p>honbun</p>
-
 <h4>subTitleH4</h4>
-
 <p>honbun</p>
-
 <pre><code># comment in code block
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
@@ -50,11 +47,8 @@ honbun
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p>honbun</p>
-
 <h4>subTitleH4</h4>
-
 <p>honbun</p>
-
 <pre><code># comment in code block
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
@@ -95,9 +89,7 @@ replace
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "replaceTitle" ) %></h3>
 <p>replace</p>
-
 <h4>replaceTitleH4</h4>
-
 <p>replace</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -125,9 +117,7 @@ http://www.google.com
 <ul>
 <li><a href="http://www.google.com">http://www.google.com</a></li>
 </ul>
-
 <p><a href="https://www.google.com">google</a></p>
-
 <p><a href="http://www.google.com">http://www.google.com</a></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -152,7 +142,6 @@ http://www.google.com
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p><img src="http://www.google.com/logo.jpg" alt=""></p>
-
 <p><img src="http://www.google.com/logo.jpg" alt="google"></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -258,9 +247,7 @@ EOS
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p><%=plugin 'val'%></p>
-
 <p><%=plugin "val", 'val'%></p>
-
 <p><%=plugin <<EOS, 'val'
 valval
 valval
@@ -312,7 +299,6 @@ EOS
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p><%=my "20120101p01", "20120101p01" %></p>
-
 <p><%=my "20120101p01", "Link" %></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -364,7 +350,6 @@ EOS
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p>@<a class="tweet-url username" href="https://twitter.com/a_matsuda" rel="nofollow">a_matsuda</a> is amatsuda</p>
-
 <p><%=isbn_left_image ''%></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -412,7 +397,6 @@ EOS
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <pre><code>p :some_code
 </code></pre>
-
 <p>@a_matsuda is amatsuda</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -437,7 +421,6 @@ EOS
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p><code>:some_code</code></p>
-
 <p>@a_matsuda is amatsuda</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -576,9 +559,7 @@ ruby -e "puts \"hello, world.\""
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <pre><code>ruby -e &quot;puts \&quot;hello, world.\&quot;&quot;
 </code></pre>
-
 <p><code>ruby -e &quot;puts \&quot;hello, world.\&quot;&quot;</code></p>
-
 <p><%=plugin "\0", "\1", "\2"%></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -607,10 +588,8 @@ NOTE: `{{.NetworkSettings.IPAddress}}` is golang template.
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
 <p>Get IP Address of Docker Container:</p>
-
 <pre><code>% docker inspect -f &quot;{{.NetworkSettings.IPAddress}}  {{.Config.Hostname}}  # Name:{{.Name}}&quot; `docker ps -q`
 </code></pre>
-
 <p>NOTE: <code>{{.NetworkSettings.IPAddress}}</code> is golang template.</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -192,8 +192,8 @@ http://example.com is example.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<div class="highlight"><pre class="highlight"><code><span class="vi">@foo</span>
-</code></pre></div>
+<pre><code class="language-ruby">@foo
+</code></pre>
 <p><a href="http://example.com">http://example.com</a> is example.com</p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -324,10 +324,11 @@ EOS
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<div class="highlight"><pre class="highlight"><code> <span class="k">def</span> <span class="nf">class</span>
-   <span class="vi">@foo</span> <span class="o">=</span> <span class="s1">'bar'</span>
- <span class="k">end</span>
-</code></pre></div><%=section_leave_proc( Time.at( 1041346800 ) )%>
+<pre><code class="language-ruby"> def class
+   @foo = 'bar'
+ end
+</code></pre>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
 			EOF
 		end

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -141,8 +141,8 @@ http://www.google.com
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
-<p><img src="http://www.google.com/logo.jpg" alt=""></p>
-<p><img src="http://www.google.com/logo.jpg" alt="google"></p>
+<p><img src="http://www.google.com/logo.jpg" alt="" /></p>
+<p><img src="http://www.google.com/logo.jpg" alt="google" /></p>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
          EOF

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'github-markdown'
+  spec.add_dependency 'commonmarker'
   spec.add_dependency 'rouge', '>= 2.2'
   spec.add_dependency 'twitter-text', '~> 1.0'
   spec.add_dependency 'emot'

--- a/tdiary-style-gfm.gemspec
+++ b/tdiary-style-gfm.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'commonmarker'
-  spec.add_dependency 'rouge', '>= 2.2'
   spec.add_dependency 'twitter-text', '~> 1.0'
   spec.add_dependency 'emot'
 


### PR DESCRIPTION
`github-markdown` gem was deprecated from 2015: https://rubygems.org/gems/github-markdown

I replaced it with commonmarker supported reference implementation of GitHub Flavored Markdown. ref. https://github.com/github/cmark

and I gave up to support ruby level syntax highlighting for code blocks. Therefore, I removed rouge from this dependencies. I suggest to use highlight.js for code highlighting with tdiary-style-gfm.