### PR TITLE
Add the render option UNSAFE to the render command of CommonMarker

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -63,7 +63,7 @@ module TDiary
 				r = replaced_r
 
 				# 2. Apply markdown conversion
-				r = CommonMarker.render_html(r, [:DEFAULT], [:autolink, :table])
+				r = CommonMarker.render_html(r, [:DEFAULT, :UNSAFE], [:autolink, :table])
 
 				# 3. Stash <pre> and <code> tags
 				pre_tag_stashes = []


### PR DESCRIPTION
commonmarker の v0.18.1 で raw HTML のレンダリングがされないことがディフォルトになったため、:UNSAFE オプションを付して、以前の動作に戻します。

関連 issue: https://github.com/tdiary/tdiary-style-gfm/issues/26