### PR TITLE
Disable Twitter autolinker if `@options['gfm.twitter_autolink']` is `false`

### DIFF
--- a/lib/tdiary/style/gfm.rb
+++ b/lib/tdiary/style/gfm.rb
@@ -102,7 +102,9 @@ module TDiary
 					end
 
 					# STAGE 3: Apply Twitter's autolinker for @mentions and lists.
-					r = Twitter::TwitterText::Autolink.auto_link_usernames_or_lists(r)
+					if TDiary.configuration.options['gfm.twitter_autolink'] != false
+						r = Twitter::TwitterText::Autolink.auto_link_usernames_or_lists(r)
+					end
 
 					# STAGE 4: Restore protected YouTube links (as new <a> tags)
 					youtube_link_data_for_twitter_text_protection.each do |link_data|

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -434,6 +434,32 @@ EOS
 		end
   end
 
+	describe 'twitter autolink disabled' do
+		before do
+			configuration_double = double('TDiaryConfiguration', options: { 'gfm.twitter_autolink' => false })
+			allow(TDiary).to receive(:configuration).and_return(configuration_double)
+
+			@diary = TDiary::Style::GfmDiary.new(Time.at( 1041346800 ), "TITLE", "")
+
+			source = <<-'EOF'
+# subTitle
+
+@a_matsuda is amatsuda
+			EOF
+			@diary.append(source)
+
+			@html = <<-'EOF'
+<div class="section">
+<%=section_enter_proc( Time.at( 1041346800 ) )%>
+<h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
+<p>@a_matsuda is amatsuda</p>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</div>
+			EOF
+		end
+		it { expect(@diary.to_html).to eq @html }
+	end
+
 	context 'emoji' do
 		describe 'in plain context' do
 			before do

--- a/spec/tdiary/style/gfm_spec.rb
+++ b/spec/tdiary/style/gfm_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 
 describe TDiary::Style::GfmDiary do
 	before do
+		configuration_double = double('TDiaryConfiguration', options: { 'gfm.twitter_autolink' => true })
+		allow(TDiary).to receive(:configuration).and_return(configuration_double)
+
 		@diary = TDiary::Style::GfmDiary.new(Time.at( 1041346800 ), "TITLE", "")
 	end
 


### PR DESCRIPTION
It seems that #31 fixed YouTube URLs, but the following embedded post still gets broken.

```html
<blockquote class="mastodon-embed" data-embed-url="https://social.shugo.net/@shugo/115664049417440698/embed" style="background: #FCF8FF; border-radius: 8px; border: 1px solid #C9C4DA; margin: 0; max-width: 540px; min-width: 270px; overflow: hidden; padding: 0;"> <a href="https://social.shugo.net/@shugo/115664049417440698" target="_blank" style="align-items: center; color: #1C1A25; display: flex; flex-direction: column; font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Roboto, sans-serif; font-size: 14px; justify-content: center; letter-spacing: 0.25px; line-height: 20px; padding: 24px; text-decoration: none;"> <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 79 75"><path d="M63 45.3v-20c0-4.1-1-7.3-3.2-9.7-2.1-2.4-5-3.7-8.5-3.7-4.1 0-7.2 1.6-9.3 4.7l-2 3.3-2-3.3c-2-3.1-5.1-4.7-9.2-4.7-3.5 0-6.4 1.3-8.6 3.7-2.1 2.4-3.1 5.6-3.1 9.7v20h8V25.9c0-4.1 1.7-6.2 5.2-6.2 3.8 0 5.8 2.5 5.8 7.4V37.7H44V27.1c0-4.9 1.9-7.4 5.8-7.4 3.5 0 5.2 2.1 5.2 6.2V45.3h8ZM74.7 16.6c.6 6 .1 15.7.1 17.3 0 .5-.1 4.8-.1 5.3-.7 11.5-8 16-15.6 17.5-.1 0-.2 0-.3 0-4.9 1-10 1.2-14.9 1.4-1.2 0-2.4 0-3.6 0-4.8 0-9.7-.6-14.4-1.7-.1 0-.1 0-.1 0s-.1 0-.1 0 0 .1 0 .1 0 0 0 0c.1 1.6.4 3.1 1 4.5.6 1.7 2.9 5.7 11.4 5.7 5 0 9.9-.6 14.8-1.7 0 0 0 0 0 0 .1 0 .1 0 .1 0 0 .1 0 .1 0 .1.1 0 .1 0 .1.1v5.6s0 .1-.1.1c0 0 0 0 0 .1-1.6 1.1-3.7 1.7-5.6 2.3-.8.3-1.6.5-2.4.7-7.5 1.7-15.4 1.3-22.7-1.2-6.8-2.4-13.8-8.2-15.5-15.2-.9-3.8-1.6-7.6-1.9-11.5-.6-5.8-.6-11.7-.8-17.5C3.9 24.5 4 20 4.9 16 6.7 7.9 14.1 2.2 22.3 1c1.4-.2 4.1-1 16.5-1h.1C51.4 0 56.7.8 58.1 1c8.4 1.2 15.5 7.5 16.6 15.6Z" fill="currentColor"/></svg> <div style="color: #787588; margin-top: 16px;">Post by @shugo@social.shugo.net</div> <div style="font-weight: 500;">View on Mastodon</div> </a> </blockquote> <script data-allowed-prefixes="https://social.shugo.net/" async src="https://social.shugo.net/embed.js"></script>
```

How about to introduce `@options['gfm.twitter_autolink']` to disable Twitter autolinker completely.
I believe Twitter is no longer the dominant platform.